### PR TITLE
POST requests for directly getting results for a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ Same as for the individual applications
 
 &lt;server&gt;/check gives a basic/primitive UI. Select the valildation type (service list or Content Guide) and provide either a URL or local file. Press "Validate!" button. Await results!
 
-&lt;server&gt;/validate_sl?url=&lt;service_list_url&gt; gives the validation results of the service list in the "url"-parameter as HTML, same format as the /check validation 
+&lt;server&gt;/validate_sl?url=&lt;service_list_url&gt; gives the validation results of the service list in the "url"-parameter as HTML, same format as the /check validation. Also accepts POST request with the servicelist in the request body with content type "application/xml". The url query parameter in the POST request can be used to show the name of the list in the resulting HTML
 
-&lt;server&gt;/validate_sl_json?url=&lt;service_list_url&gt; valdiates the list in the "url"-parameter and gives the number of errors, warnings and informationals as JSON, 
+&lt;server&gt;/validate_sl_json?url=&lt;service_list_url&gt; valdiates the list in the "url"-parameter and gives the number of errors, warnings and informationals as JSON. Also accepts POST request with the servicelist in the request body with content type "application/xml"  instead of the url query parameter. Example response:
 ```json
 {
   "errors":1,
@@ -180,7 +180,7 @@ Same as for the individual applications
   "informationals":0
 }
 ```
-&lt;server&gt;/validate_sl_json?url=&lt;service_list_url&gt;&results=all valdiates the list "url"-parameter and gives the complete validation results as JSON
+&lt;server&gt;/validate_sl_json?url=&lt;service_list_url&gt;&results=all valdiates the list "url"-parameter and gives the complete validation results as JSON. Also accepts POST request with the servicelist in the request body with content type "application/xml" instead of the url query parameter. Example response:
 ```json
 {
   "errs":

--- a/Validator.js
+++ b/Validator.js
@@ -188,14 +188,19 @@ function validateServiceList(req, res, slcheck) {
 	let errs = new ErrorList();
 	let resp, VVxml = null;
 	let log_prefix = createPrefix(req, res);
-	try {
-		resp = fetchS(req.query.url);
-	} catch (error) {
-		req.parseErr = error.message;
+	if(req.method == "GET") {
+		try {
+			resp = fetchS(req.query.url);
+		} catch (error) {
+			req.parseErr = error.message;
+		}
+		if (resp) {
+			if (resp.ok) VVxml = resp.text();
+			else req.parseErr = `error (${resp.status}:${resp.statusText}) handling ${req.body.XMLurl}`;
+		}
 	}
-	if (resp) {
-		if (resp.ok) VVxml = resp.text();
-		else req.parseErr = `error (${resp.status}:${resp.statusText}) handling ${req.body.XMLurl}`;
+	else if(req.method == "POST") {
+		VVxml = req.body
 	}
 	slcheck.doValidateServiceList(VVxml, errs, log_prefix);
 	drawResults(req,res, req.parseErr, errs);
@@ -208,14 +213,19 @@ function validateServiceListJson(req, res, slcheck) {
 	let errs = new ErrorList();
 	let resp, VVxml = null;
 	let log_prefix = createPrefix(req, res);
-	try {
-		resp = fetchS(req.query.url);
-	} catch (error) {
-		req.parseErr = error.message;
+	if(req.method == "GET") {
+		try {
+			resp = fetchS(req.query.url);
+		} catch (error) {
+			req.parseErr = error.message;
+		}
+		if (resp) {
+			if (resp.ok) VVxml = resp.text();
+			else req.parseErr = `error (${resp.status}:${resp.statusText}) handling ${req.body.XMLurl}`;
+		}
 	}
-	if (resp) {
-		if (resp.ok) VVxml = resp.text();
-		else req.parseErr = `error (${resp.status}:${resp.statusText}) handling ${req.body.XMLurl}`;
+	else if(req.method == "POST") {
+		VVxml = req.body
 	}
 	slcheck.doValidateServiceList(VVxml, errs, log_prefix);
 	res.setHeader("Content-Type", "application/json");
@@ -374,6 +384,14 @@ export default function validator(options) {
 
 		app.get("/validate_sl_json", function (req, res) {
 			validateServiceListJson(req, res, slcheck);
+		});
+
+		app.post("/validate_sl",express.text({type: "application/xml",limit: '2mb'}), function (req, res) {
+			validateServiceList(req, res,slcheck);
+		});
+
+		app.post("/validate_sl_json",express.text({type: "application/xml",limit: '2mb'}), function (req, res) {
+			validateServiceListJson(req, res,slcheck);
 		});
 	}
 

--- a/ui.js
+++ b/ui.js
@@ -199,7 +199,7 @@ export function drawForm(deprecateTo, req, res, modes, supportedRequests, error 
 export function drawResults(req, res, error = null, errs = null) {
 	res.setHeader("Content-Type", "text/html");
 	res.write(PAGE_TOP("DVB-I Validator", "DVB-I Validator"));
-	tabulateResults(req.query.url, res, error, errs);
+	tabulateResults(req.query.url? req.query.url : "uploaded list" , res, error, errs);
 	res.write(PAGE_BOTTOM);
 	return new Promise((resolve, /* eslint-disable no-unused-vars */ reject /* eslint-enable */) => {
 		resolve(res);


### PR DESCRIPTION
validate_sl and validate_sl_json endpoints also accept POST requests with the servicelist in the request body with applicatio/xml content type. 