### PR TITLE
Increase service list maximum size that can be validated with a POST request to 10 mb

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -321,11 +321,11 @@ export default function validator(options) {
 			validateServiceListJson(req, res, slcheck);
 		});
 
-		app.post("/validate_sl", express.text({ type: "application/xml", limit: "2mb" }), function (req, res) {
+		app.post("/validate_sl", express.text({ type: "application/xml", limit: "10mb" }), function (req, res) {
 			validateServiceList(req, res, slcheck);
 		});
 
-		app.post("/validate_sl_json", express.text({ type: "application/xml", limit: "2mb" }), function (req, res) {
+		app.post("/validate_sl_json", express.text({ type: "application/xml", limit: "10mb" }), function (req, res) {
 			validateServiceListJson(req, res, slcheck);
 		});
 	}


### PR DESCRIPTION
When using the POST-request to validate a service list we found that the 2mb limit was too small, 10mb should be enough for a while