### PR TITLE
Use https for the phlib submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "phlib"]
 	path = phlib
-	url = http://github.com/paulhiggs/phlib
+	url = https://github.com/paulhiggs/phlib
 [submodule "testsuite"]
 	path = testsuite
 	url = https://github.com/paulhiggs/dvb-i-tools.testsuite


### PR DESCRIPTION
Some git clients refuse to clone submodules using http and others give a warning and redirects the url to https:
`
warning: redirecting to https://github.com/paulhiggs/phlib/
`
As the testsuite submodule already uses https-protocol, I think this change should not cause any issues?